### PR TITLE
replace default path by specified path

### DIFF
--- a/pysdfgen/__init__.py
+++ b/pysdfgen/__init__.py
@@ -1,3 +1,4 @@
+import os
 import os.path as osp
 import pkg_resources
 import subprocess
@@ -38,11 +39,14 @@ def obj2sdf(obj_filepath, dim=100, padding=5,
     _, ext = osp.splitext(obj_filepath)
     if ext != '.obj':
         raise ValueError("The input file name should end with '.obj'.")
+
+    parent = osp.dirname(obj_filepath)
+    basename = osp.basename(obj_filepath)
+    stem, _ = osp.splitext(basename)
+    default_sdf_filepath = osp.join(parent, stem + ".sdf")
+
     if output_filepath is None:
-        parent = osp.dirname(obj_filepath)
-        basename = osp.basename(obj_filepath)
-        stem, _ = osp.splitext(basename)
-        sdf_filepath = osp.join(parent, stem + ".sdf")
+        sdf_filepath = default_sdf_filepath
     else:
         sdf_filepath = output_filepath
 
@@ -56,4 +60,7 @@ def obj2sdf(obj_filepath, dim=100, padding=5,
          str(padding)],
         stdout=DEVNULL)
     p.wait()
+
+    # becuase the output destination of SDFGen can't be specified...
+    os.replace(default_sdf_filepath, sdf_filepath)
     return sdf_filepath

--- a/pysdfgen/__init__.py
+++ b/pysdfgen/__init__.py
@@ -62,5 +62,5 @@ def obj2sdf(obj_filepath, dim=100, padding=5,
     p.wait()
 
     # becuase the output destination of SDFGen can't be specified...
-    os.replace(default_sdf_filepath, sdf_filepath)
+    os.rename(default_sdf_filepath, sdf_filepath)
     return sdf_filepath

--- a/pysdfgen/__init__.py
+++ b/pysdfgen/__init__.py
@@ -1,7 +1,7 @@
-import os
 import os.path as osp
-import pkg_resources
 import subprocess
+
+import pkg_resources
 
 try:
     from subprocess import DEVNULL

--- a/tests/pysdfgen_tests/test_sdfgen.py
+++ b/tests/pysdfgen_tests/test_sdfgen.py
@@ -46,7 +46,7 @@ class TestSDFGen(unittest.TestCase):
                                       output_filepath=another_bunny_sdfpath,
                                       overwrite=True)
         self.assertEqual(another_output_path, another_bunny_sdfpath)
-        assert os.path.exists(another_bunny_sdfpath)
+        self.assertTrue(os.path.exists(another_bunny_sdfpath))
 
         with self.assertRaises(OSError):
             obj2sdf(bunny_objpath,

--- a/tests/pysdfgen_tests/test_sdfgen.py
+++ b/tests/pysdfgen_tests/test_sdfgen.py
@@ -4,10 +4,14 @@ import unittest
 
 from pysdfgen import obj2sdf
 
-
 current_dir = osp.abspath(osp.dirname(__file__))
 bunny_objpath = osp.join(current_dir, 'data', 'bunny.obj')
 bunny_sdfpath = osp.join(current_dir, 'data', 'bunny.sdf')
+
+another_data_dir = osp.join(current_dir, "tmp")
+another_bunny_sdfpath = osp.join(another_data_dir, 'bunny.sdf')
+if not os.path.exists(another_data_dir):
+    os.makedirs(another_data_dir)
 
 
 class TestSDFGen(unittest.TestCase):
@@ -34,4 +38,18 @@ class TestSDFGen(unittest.TestCase):
         with self.assertRaises(OSError):
             obj2sdf(bunny_objpath,
                     output_filepath=bunny_sdfpath,
+                    overwrite=False)
+
+        # testing the case when a custom output path is specified
+        another_output_path = obj2sdf(bunny_objpath,
+                                      dim=dim,
+                                      output_filepath=another_bunny_sdfpath,
+                                      overwrite=True)
+        self.assertEqual(another_output_path, another_bunny_sdfpath)
+        assert os.path.exists(another_bunny_sdfpath)
+
+        with self.assertRaises(OSError):
+            obj2sdf(bunny_objpath,
+                    dim=dim,
+                    output_filepath=another_bunny_sdfpath,
                     overwrite=False)


### PR DESCRIPTION
In the original implementation, the specified output_path is not actually used in the program, so I fixed it. 

As far as I know SDFGen does not allow us to specify the output file destination. Therefore, I use `os.replace` to replace the default output path of SDFGen by the specified path of the user.  