### PR TITLE
fix pos of import os

### DIFF
--- a/pysdfgen/__init__.py
+++ b/pysdfgen/__init__.py
@@ -1,3 +1,4 @@
+import os
 import os.path as osp
 import subprocess
 
@@ -6,7 +7,6 @@ import pkg_resources
 try:
     from subprocess import DEVNULL
 except ImportError:
-    import os
     DEVNULL = open(os.devnull, 'wb')
 
 


### PR DESCRIPTION
In the previous my commit https://github.com/iory/pySDFGen/pull/3/files , I forget adding `import os`, but test mistakenly passed because probably https://github.com/iory/pySDFGen/blob/8034b47d3e05d3589b96e76e911ccc08ce01d340/pysdfgen/__init__.py#L9 is called inside exception handling.  

But it must be placed in the top of the script. So I fixed it. 

Without fixing it, in my environment, the pytest fails with 
```
>       os.rename(default_sdf_filepath, sdf_filepath)
E       NameError: name 'os' is not defined

../../../.pyenv/versions/3.7.7/lib/python3.7/site-packages/pysdfgen/__init__.py:65: NameError
```