### PR TITLE
fix: json encoder error while pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ def get_or_install(name, version=None):
         # valid names & versions are ASCII as per PEP 440
         subprocess.check_output(
             [sys.executable,
-             "-m", "pip", "list", "--format", "json"]).decode('ascii'))
+             "-m", "pip", "list", "--format", "json", "--disable-pip-version-check"]).decode('ascii'))
     try:
         [package] = (package for package in js_packages
                      if package['name'] == name)

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,8 @@ def get_or_install(name, version=None):
         # valid names & versions are ASCII as per PEP 440
         subprocess.check_output(
             [sys.executable,
-             "-m", "pip", "list", "--format", "json", "--disable-pip-version-check"]).decode('ascii'))
+             "-m", "pip", "list", "--format", "json",
+             "--disable-pip-version-check"]).decode('ascii'))
     try:
         [package] = (package for package in js_packages
                      if package['name'] == name)


### PR DESCRIPTION
## description
fix https://github.com/iory/pySDFGen/issues/14
pip install pysdfgen fails if one use `pip==22.1.2`. This is problematic because from yesterday, the  github action actions/setup-python starts to use pip==22.1.2. 

The reason of the bug is `pip list` gives extra strings 
```
[notice] A new release of pip available: 22.1.2 -> 22.2
[notice] To update, run: pip install --upgrade pip
```
which causes `json.decoder.JSONDecodeError` in https://github.com/iory/pySDFGen/blob/1fea15dbcc82afe6f2fdaf91eebc39cf1bff3af8/setup.py#L76

To circumvent this, this PR surppress this notice by adding `--disable-pip-version-check`.

## behavior change
After this PR
```
h-ishida@stone-jsk:~/python/pySDFGen$ python3 -m pip --version
pip 22.1.2 from /home/h-ishida/.pyenv/versions/3.8.10/lib/python3.8/site-packages/pip (python 3.8)
h-ishida@stone-jsk:~/python/pySDFGen$ pip3 install -e .
Obtaining file:///home/h-ishida/python/pySDFGen
  Preparing metadata (setup.py) ... done
Requirement already satisfied: scikit-build in /home/h-ishida/.local/lib/python3.8/site-packages (from pysdfgen==0.1.5) (0.15.0)
Requirement already satisfied: trimesh>=3.5.20 in /home/h-ishida/.local/lib/python3.8/site-packages (from pysdfgen==0.1.5) (3.12.6)
Requirement already satisfied: numpy in /home/h-ishida/.local/lib/python3.8/site-packages (from trimesh>=3.5.20->pysdfgen==0.1.5) (1.23.0)
Requirement already satisfied: distro in /home/h-ishida/.pyenv/versions/3.8.10/lib/python3.8/site-packages (from scikit-build->pysdfgen==0.1.5) (1.7.0)
Requirement already satisfied: wheel>=0.29.0 in /home/h-ishida/.pyenv/versions/3.8.10/lib/python3.8/site-packages (from scikit-build->pysdfgen==0.1.5) (0.37.1)
Requirement already satisfied: packaging in /home/h-ishida/.pyenv/versions/3.8.10/lib/python3.8/site-packages (from scikit-build->pysdfgen==0.1.5) (21.3)
Requirement already satisfied: setuptools>=28.0.0 in /home/h-ishida/.pyenv/versions/3.8.10/lib/python3.8/site-packages (from scikit-build->pysdfgen==0.1.5) (56.0.0)
Requirement already satisfied: pyparsing!=3.0.5,>=2.0.2 in /home/h-ishida/.pyenv/versions/3.8.10/lib/python3.8/site-packages (from packaging->scikit-build->pysdfgen==0.1.5) (3.0.9)
Installing collected packages: pysdfgen
  Attempting uninstall: pysdfgen
    Found existing installation: pysdfgen 0.1.5
    Uninstalling pysdfgen-0.1.5:
      Successfully uninstalled pysdfgen-0.1.5
  Running setup.py develop for pysdfgen
Successfully installed pysdfgen

[notice] A new release of pip available: 22.1.2 -> 22.2
[notice] To update, run: pip install --upgrade pip
```

Before this PR: 
```
h-ishida@stone-jsk:~/python/pySDFGen$ python3 -m pip --version
pip 22.1.2 from /home/h-ishida/.pyenv/versions/3.8.10/lib/python3.8/site-packages/pip (python 3.8)
h-ishida@stone-jsk:~/python/pySDFGen$ pip3 install -e .
Obtaining file:///home/h-ishida/python/pySDFGen
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [14 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/home/h-ishida/python/pySDFGen/setup.py", line 99, in <module>
          main()
        File "/home/h-ishida/python/pySDFGen/setup.py", line 92, in main
          get_or_install('scikit-build')
        File "/home/h-ishida/python/pySDFGen/setup.py", line 76, in get_or_install
          js_packages = json.loads(
        File "/home/h-ishida/.pyenv/versions/3.8.10/lib/python3.8/json/__init__.py", line 357, in loads
          return _default_decoder.decode(s)
        File "/home/h-ishida/.pyenv/versions/3.8.10/lib/python3.8/json/decoder.py", line 340, in decode
          raise JSONDecodeError("Extra data", s, end)
      json.decoder.JSONDecodeError: Extra data: line 3 column 1 (char 10073)
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.

[notice] A new release of pip available: 22.1.2 -> 22.2
[notice] To update, run: pip install --upgrade pip
```