### PR TITLE
Do not use SIMD flags when building not on x64_64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,12 @@ set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin)
 #These flags might not work on every system, especially the release flags, comment out as needed
 set(CMAKE_CXX_FLAGS "-O3")
 set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g")
-set(CMAKE_CXX_FLAGS_RELEASE "-O3 -msse4.2 -mfpmath=sse -mtune=native")
 
+IF(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64")
+    set(CMAKE_CXX_FLAGS_RELEASE "-O3 -msse4.2 -mfpmath=sse -mtune=native")
+ELSE()
+    set(CMAKE_CXX_FLAGS_RELEASE "-O3 -mtune=native")
+ENDIF()
 
 add_executable(${PROJECT_NAME}
   SDFGen/main.cpp  SDFGen/makelevelset3.cpp SDFGen/array1.h  SDFGen/array2.h  SDFGen/array3.h  SDFGen/hashgrid.h  SDFGen/hashtable.h SDFGen/makelevelset3.h  SDFGen/util.h  SDFGen/vec.h


### PR DESCRIPTION
Currently pip installing pysdfgen (so scikit-robot) fails on arm64. This PR fix the issue.