### PR TITLE
fix: raise appropriate error when command with invalid args 

### DIFF
--- a/pysdfgen/__init__.py
+++ b/pysdfgen/__init__.py
@@ -86,8 +86,20 @@ def mesh2sdf(mesh_filepath, dim=100, padding=5,
          str(obj_filepath),
          str(dim),
          str(padding)],
-        stdout=DEVNULL)
-    p.wait()
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE)
+
+    stdout, stderr = p.communicate()
+    stdout_decoded = stdout.decode('utf-8').strip()
+    stderr_decoded = stderr.decode('utf-8').strip()
+
+    if p.returncode != 0:
+        error_message = "SDFGen failed."
+        if stdout_decoded:
+            error_message += " stdout: '{}'".format(stdout_decoded)
+        if stderr_decoded:
+            error_message += " stderr: '{}'".format(stderr_decoded)
+        raise ValueError(error_message)
 
     if is_obj_file:
         # becuase the output destination of SDFGen can't be specified...

--- a/tests/pysdfgen_tests/test_sdfgen.py
+++ b/tests/pysdfgen_tests/test_sdfgen.py
@@ -34,8 +34,8 @@ class TestSDFGen(unittest.TestCase):
         if osp.exists(bunny_sdfpath):
             os.remove(bunny_sdfpath)
         # padding must be smaller than dim
-        obj2sdf(bunny_objpath, dim=10, padding=20)
-        os.remove(bunny_sdfpath)
+        with self.assertRaises(ValueError):
+            obj2sdf(bunny_objpath, dim=10, padding=10)
 
     def test_mesh2sdf(self):
         dim = 10

--- a/tests/pysdfgen_tests/test_sdfgen.py
+++ b/tests/pysdfgen_tests/test_sdfgen.py
@@ -30,6 +30,13 @@ class TestSDFGen(unittest.TestCase):
         self.assertEqual(output_path, bunny_sdfpath)
         os.remove(bunny_sdfpath)
 
+    def test_invalid_arg_to_command(self):
+        if osp.exists(bunny_sdfpath):
+            os.remove(bunny_sdfpath)
+        # padding must be smaller than dim
+        obj2sdf(bunny_objpath, dim=10, padding=20)
+        os.remove(bunny_sdfpath)
+
     def test_mesh2sdf(self):
         dim = 10
         if osp.exists(bunny_sdfpath):


### PR DESCRIPTION
**this PR is ready to be reviewed!**

when args to the sdfgen cmd are invalid, the cmd does not produce the sdf and show the reason how the argument was invalid. However, in current implementation, we don't check the return code of the subprocess and just show the encounter the following error:
(In this case I set dim=10 and padding=10, which is invalid because dim always must be greater than padding)
```
h-ishida@azarashi:~/python/pySDFGen$ python3 -c "from pysdfgen import mesh2sdf; mesh2sdf('./examples/bunny.obj', dim=10, padding=10)"
Traceback (most recent call last):
  File "/usr/lib/python3.8/shutil.py", line 791, in move
    os.rename(src, real_dst)
FileNotFoundError: [Errno 2] No such file or directory: './examples/bunny.sdf' -> './examples/bunny.sdf'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/h-ishida/python/pySDFGen/pysdfgen/__init__.py", line 94, in mesh2sdf
    shutil.move(default_sdf_filepath, sdf_filepath)
  File "/usr/lib/python3.8/shutil.py", line 811, in move
    copy_function(src, real_dst)
  File "/usr/lib/python3.8/shutil.py", line 435, in copy2
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "/usr/lib/python3.8/shutil.py", line 264, in copyfile
    with open(src, 'rb') as fsrc, open(dst, 'wb') as fdst:
FileNotFoundError: [Errno 2] No such file or directory: './examples/bunny.sdf'
```
which is quite unfriendly. 

This PR, pipes the stdout and stderr and if return code is nonzero, raise an exception with stdout and stderr if they are not empty. By this  PR, the same command produce more debuggable information piped from SDFGen

```
h-ishida@azarashi:~/python/pySDFGen$ python3 -c "from pysdfgen import mesh2sdf; mesh2sdf('./examples/bunny.obj', dim=10, padding=10)"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/h-ishida/python/pySDFGen/pysdfgen/__init__.py", line 102, in mesh2sdf
    raise ValueError(error_message)
ValueError: SDFGen failed. stdout: 'Padding greater than cube dim'
```
