### PR TITLE
Replace pkg_resources with importlib.metadata for Python 3.8+ compatibility

### DIFF
--- a/pysdfgen/__init__.py
+++ b/pysdfgen/__init__.py
@@ -2,6 +2,7 @@ import os
 import os.path as osp
 import shutil
 import subprocess
+import sys
 import tempfile
 import warnings
 
@@ -13,6 +14,25 @@ except ImportError:
 
 
 _version = None
+
+
+def _get_version():
+    global _version
+    if _version is None:
+        try:
+            # Python 3.8+
+            import importlib.metadata
+            _version = importlib.metadata.version('pysdfgen')
+        except ImportError:
+            # Python < 3.8 fallback
+            import pkg_resources
+            _version = pkg_resources.get_distribution('pysdfgen').version
+    return _version
+
+
+# For Python 2.7 compatibility, explicitly define __version__
+if sys.version_info[0] == 2:
+    __version__ = _get_version()
 _SUBMODULES = [
     "obj2sdf",
     "mesh2sdf",
@@ -34,18 +54,8 @@ def _lazy_trimesh():
 
 
 def __getattr__(name):
-    global _version
     if name == "__version__":
-        if _version is None:
-            try:
-                import importlib.metadata
-                _version = importlib.metadata.version('pysdfgen')
-            except ImportError:
-                # Fallback for Python < 3.8
-                import pkg_resources
-                _version = pkg_resources.get_distribution(
-                    'pysdfgen').version
-        return _version
+        return _get_version()
     raise AttributeError(
         "module {} has no attribute {}".format(__name__, name))
 

--- a/pysdfgen/__init__.py
+++ b/pysdfgen/__init__.py
@@ -37,9 +37,14 @@ def __getattr__(name):
     global _version
     if name == "__version__":
         if _version is None:
-            import pkg_resources
-            _version = pkg_resources.get_distribution(
-                'pysdfgen').version
+            try:
+                import importlib.metadata
+                _version = importlib.metadata.version('pysdfgen')
+            except ImportError:
+                # Fallback for Python < 3.8
+                import pkg_resources
+                _version = pkg_resources.get_distribution(
+                    'pysdfgen').version
         return _version
     raise AttributeError(
         "module {} has no attribute {}".format(__name__, name))

--- a/tests/pysdfgen_tests/test_sdfgen.py
+++ b/tests/pysdfgen_tests/test_sdfgen.py
@@ -2,6 +2,7 @@ import os
 import os.path as osp
 import unittest
 
+import pysdfgen
 from pysdfgen import mesh2sdf
 from pysdfgen import obj2sdf
 
@@ -90,3 +91,20 @@ class TestSDFGen(unittest.TestCase):
             dim=dim)
         self.assertEqual(another_output_path, another_gripper_sdfpath)
         self.assertTrue(osp.exists(another_output_path))
+
+
+class TestVersion(unittest.TestCase):
+
+    def test_version_attribute(self):
+        """Test that __version__ attribute is accessible and returns string."""
+        version = pysdfgen.__version__
+        self.assertIsInstance(version, str)
+        self.assertTrue(len(version) > 0)
+        # Version should contain digits and dots
+        self.assertTrue(any(c.isdigit() for c in version))
+
+    def test_version_consistency(self):
+        """Test that accessing __version__ multiple times returns the same."""
+        version1 = pysdfgen.__version__
+        version2 = pysdfgen.__version__
+        self.assertEqual(version1, version2)


### PR DESCRIPTION
- Use importlib.metadata.version() instead of pkg_resources.get_distribution()
- Maintain backward compatibility with fallback to pkg_resources for Python < 3.8
- Add tests for version attribute functionality